### PR TITLE
suggestion^2: just use an re, add LEEWAY back

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -463,21 +463,18 @@ def check_script_prefixes():
     """Check that no more than `EXPECTED_VIOLATION_COUNT` of the
        test scripts don't start with one of the allowed name prefixes."""
     EXPECTED_VIOLATION_COUNT = 77
+    LEEWAY = 10
 
-    good_prefixes = ["feature_", "interface_", "mempool_", "mining_", "p2p_", "rpc_", "wallet_", "example_test"]
-    good_prefixes_re = re.compile("|".join(good_prefixes))
-
+    good_prefixes_re = re.compile("(feature|interface|mempool|mining|p2p|rpc|wallet|example)_")
     bad_script_names = [script for script in ALL_SCRIPTS if good_prefixes_re.match(script) is None]
 
     if len(bad_script_names) < EXPECTED_VIOLATION_COUNT:
         print("{}HURRAY!{} Number of functional tests violating naming convention reduced!".format(BOLD[1], BOLD[0]))
         print("Consider reducing EXPECTED_VIOLATION_COUNT from %d to %d" % (EXPECTED_VIOLATION_COUNT, len(bad_script_names)))
-    elif len(bad_script_names) == EXPECTED_VIOLATION_COUNT:
-        pass
-    else:
+    elif len(bad_script_names) > EXPECTED_VIOLATION_COUNT:
         print("INFO: tests not meeting naming conventions:")
         print("  %s" % ("\n  ".join(sorted(bad_script_names))))
-        raise(AssertionError("Too many tests not following naming convention! (%d found, expected: <= %d)" % (len(bad_script_names), EXPECTED_VIOLATION_COUNT)))
+        assert len(bad_script_names) <= EXPECTED_VIOLATION_COUNT + LEEWAY, "Too many tests not following naming convention! (%d found, expected: <= %d)" % (len(bad_script_names), EXPECTED_VIOLATION_COUNT)
 
 class RPCCoverage(object):
     """


### PR DESCRIPTION
Using re sounds fine, but might as well just write it out directly, no? Just using example as a category seems simpler and fine too.

(One advantage of the set shenanigans is that it doesn't complain twice about `txn_doublespend.py` and `txn_doublespend.py --mineblock`)

I don't think I'm comfortable dropping LEEWAY in some form or other -- the behaviour I want is for this patch not to conflict with other PRs currently in the system getting merged; but without LEEWAY if they add a test with a non-compliant name, the tests will start failing. Likewise if tests with non-compliant names get merged before this PR does, then this PR would need updating. Better to drop the assertion failure entirely than make merging harder.

The len(excess)<LEEWAY was deliberate btw -- it was to avoid spamming dozens of script names when someone introduces a single new script that doesn't conform... (And there are a couple of new scripts in master since the basis for this PR, so I think it should start spamming immediately...) Might have been trying to be too clever though.